### PR TITLE
Fixed ReloadDatabasePath for Linux OS

### DIFF
--- a/source/upascaltz.pas
+++ b/source/upascaltz.pas
@@ -965,13 +965,16 @@ begin
 end;
 
 procedure TPascalTZ.ReloadDatabasePath;
+var
+  DrExsts: Boolean;
 begin
   ClearDatabase;
   if Length(FDatabasePath) > 0 then
   begin
-    if FileExists(FDatabasePath) then
+    DrExsts:=DirectoryExists(FDatabasePath);
+    if not DrExsts and FileExists(FDatabasePath) then
       ParseDatabaseFromFile(FDatabasePath)
-    else if DirectoryExists(FDatabasePath) then
+    else if DrExsts then 
       ParseDatabaseFromDirectory(FDatabasePath)
     else
       raise TTZException.Create(Format('Time zone database path does not exist: %s', [FDatabasePath]));


### PR DESCRIPTION
On Unix, passing a directory name will result in True with FileExists function (because directory is file too in Unix). So it's valid to check if is really file not directory.
Perhaps it's more beautiful to just put a check on the directory at the beginning, but I'm not sure if this matches the logic of the code. That is it is possible and so, it is possible
```
    if DirectoryExists(FDatabasePath) then
      ParseDatabaseFromDirectory(FDatabasePath) 
    else if FileExists(FDatabasePath) then
      ParseDatabaseFromFile(FDatabasePath)
```